### PR TITLE
Fix python3.9 threading.Thread.is_alive() function renaming

### DIFF
--- a/spotify_ripper/eventloop.py
+++ b/spotify_ripper/eventloop.py
@@ -6,7 +6,7 @@
 from __future__ import unicode_literals
 
 from colorama import Fore
-import threading
+import spotify_ripper.thread as threading
 
 try:
     # Python 3

--- a/spotify_ripper/ripper.py
+++ b/spotify_ripper/ripper.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import getpass
 import itertools
-import threading
 import time
 import wave
 from subprocess import Popen, PIPE
@@ -17,6 +16,7 @@ from spotify_ripper.post_actions import PostActions
 from spotify_ripper.progress import Progress
 from spotify_ripper.sync import Sync
 from spotify_ripper.tags import set_metadata_tags
+import spotify_ripper.thread as threading
 from spotify_ripper.utils import *
 from spotify_ripper.web import WebAPI
 

--- a/spotify_ripper/thread.py
+++ b/spotify_ripper/thread.py
@@ -1,0 +1,11 @@
+import threading
+
+class Thread(threading.Thread):
+    def __init__(self):
+        threading.Thread.__init__(self)
+        
+        isAlive = getattr(self, "is_alive", None)
+        if callable(isAlive):
+            self.isAlive = isAlive
+
+Event = threading.Event


### PR DESCRIPTION
In python3.9 the function Thread.isAlive() is replaced by Thread.is_alive().